### PR TITLE
Fix GCC-11 Build Failure: include limits lib

### DIFF
--- a/src/significant_kmer.hpp
+++ b/src/significant_kmer.hpp
@@ -12,6 +12,7 @@
 #include <iterator>
 #include <algorithm>
 #include <stdexcept>
+#include <limits>
 
 const int default_covars = 0;
 const int standard_cols = 8;


### PR DESCRIPTION
Hi,

currently seer doesn't build with gcc-11 and output the following error:

```
make[3]: Entering directory '/<<PKGBUILDDIR>>/src'
g++-11 -g -O2 -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -Wall -O3 -std=c++11 -Wdate-time -D_FORTIFY_SOURCE=2 -D DLIB_NO_GUI_SUPPORT=1 -D DLIB_USE_BLAS=1 -D DLIB_USE_LAPACK=1 -DARMA_USE_HDF5=1  -c -o sample.o sample.cpp
g++-11 -g -O2 -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -Wall -O3 -std=c++11 -Wdate-time -D_FORTIFY_SOURCE=2 -D DLIB_NO_GUI_SUPPORT=1 -D DLIB_USE_BLAS=1 -D DLIB_USE_LAPACK=1 -DARMA_USE_HDF5=1  -c -o significant_kmer.o significant_kmer.cpp
g++-11 -g -O2 -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -Wall -O3 -std=c++11 -Wdate-time -D_FORTIFY_SOURCE=2 -D DLIB_NO_GUI_SUPPORT=1 -D DLIB_USE_BLAS=1 -D DLIB_USE_LAPACK=1 -DARMA_USE_HDF5=1  -c -o kmer.o kmer.cpp
g++-11 -g -O2 -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -Wall -O3 -std=c++11 -Wdate-time -D_FORTIFY_SOURCE=2 -D DLIB_NO_GUI_SUPPORT=1 -D DLIB_USE_BLAS=1 -D DLIB_USE_LAPACK=1 -DARMA_USE_HDF5=1  -c -o covar.o covar.cpp
g++-11 -g -O2 -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -Wall -O3 -std=c++11 -Wdate-time -D_FORTIFY_SOURCE=2 -D DLIB_NO_GUI_SUPPORT=1 -D DLIB_USE_BLAS=1 -D DLIB_USE_LAPACK=1 -DARMA_USE_HDF5=1  -c -o seerCommon.o seerCommon.cpp
g++-11 -g -O2 -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -Wall -O3 -std=c++11 -Wdate-time -D_FORTIFY_SOURCE=2 -D DLIB_NO_GUI_SUPPORT=1 -D DLIB_USE_BLAS=1 -D DLIB_USE_LAPACK=1 -DARMA_USE_HDF5=1  -c -o seerErr.o seerErr.cpp
significant_kmer.cpp: In function ‘std::istream& operator>>(std::istream&, Significant_kmer&)’:
significant_kmer.cpp:50:31: error: ‘numeric_limits’ is not a member of ‘std’
   50 |       line_stream.ignore(std::numeric_limits<std::streamsize>::max(), '\t');
      |                               ^~~~~~~~~~~~~~
significant_kmer.cpp:50:61: error: expected primary-expression before ‘>’ token
   50 |       line_stream.ignore(std::numeric_limits<std::streamsize>::max(), '\t');
      |                                                             ^
significant_kmer.cpp:50:64: error: ‘::max’ has not been declared; did you mean ‘std::max’?
   50 |       line_stream.ignore(std::numeric_limits<std::streamsize>::max(), '\t');
      |                                                                ^~~
      |                                                                std::max
In file included from /usr/include/c++/11/algorithm:62,
                 from significant_kmer.hpp:13,
                 from significant_kmer.cpp:9:
/usr/include/c++/11/bits/stl_algo.h:3467:5: note: ‘std::max’ declared here
 3467 |     max(initializer_list<_Tp> __l, _Compare __comp)
      |     ^~~
make[3]: *** [<builtin>: significant_kmer.o] Error 1
make[3]: *** Waiting for unfinished jobs....
make[3]: Leaving directory '/<<PKGBUILDDIR>>/src'
make[2]: *** [Makefile:5: all] Error 2
make[2]: Leaving directory '/<<PKGBUILDDIR>>'
dh_auto_build: error: make -j5 "INSTALL=install --strip-program=true" LDFLAGS\+=-L/usr/lib/x86_64-linux-gnu/hdf5/serial returned exit code 2
make[1]: *** [debian/rules:14: override_dh_auto_build] Error 25
make[1]: Leaving directory '/<<PKGBUILDDIR>>'
make: *** [debian/rules:26: binary] Error 2
```

This PR is an attempt to fix it -- it builds on applying this patch